### PR TITLE
Write version hint file

### DIFF
--- a/src/iceberg_destination.rs
+++ b/src/iceberg_destination.rs
@@ -110,11 +110,7 @@ pub async fn record_batches_to_iceberg(
     )?);
 
     let version_hint_location = format!("{}/metadata/version-hint.text", target_url);
-    if file_io
-        .new_input(&version_hint_location)?
-        .exists()
-        .await
-    {
+    if file_io.new_input(&version_hint_location)?.exists().await? {
         return Err(DataLoadingError::IcebergError(iceberg::Error::new(
             iceberg::ErrorKind::FeatureUnsupported,
             "Iceberg table already exists. Writing to an existing table is not implemented",

--- a/src/iceberg_destination.rs
+++ b/src/iceberg_destination.rs
@@ -108,6 +108,15 @@ pub async fn record_batches_to_iceberg(
     let iceberg_schema = Arc::new(iceberg::arrow::arrow_schema_to_schema(
         &arrow_schema_with_ids,
     )?);
+
+    let version_hint_location = format!("{}/metadata/version-hint.text", target_url);
+    if let Ok(_) = file_io.new_input(&version_hint_location)?.read().await {
+        return Err(DataLoadingError::IcebergError(iceberg::Error::new(
+            iceberg::ErrorKind::FeatureUnsupported,
+            "Iceberg table already exists. Writing to an existing table is not implemented",
+        )));
+    };
+
     let metadata_v0 = create_metadata_v0(&iceberg_schema, target_url.to_string())?;
     let metadata_v0_location = format!("{}/metadata/v0.metadata.json", target_url);
 
@@ -217,7 +226,7 @@ pub async fn record_batches_to_iceberg(
         .build();
 
     let metadata_v1 = create_metadata_v1(&metadata_v0, snapshot)?;
-    let metadata_v1_location = format!("{}/metadata/v1.metadata.json", target_url,);
+    let metadata_v1_location = format!("{}/metadata/v1.metadata.json", target_url);
 
     file_io
         .new_output(&metadata_v1_location)?
@@ -225,7 +234,6 @@ pub async fn record_batches_to_iceberg(
         .await?;
     info!("Wrote v1 metadata: {:?}", metadata_v1_location);
 
-    let version_hint_location = format!("{}/metadata/version-hint.text", target_url,);
     file_io
         .new_output(&version_hint_location)?
         .write("1".to_string().into())

--- a/src/iceberg_destination.rs
+++ b/src/iceberg_destination.rs
@@ -225,5 +225,12 @@ pub async fn record_batches_to_iceberg(
         .await?;
     info!("Wrote v1 metadata: {:?}", metadata_v1_location);
 
+    let version_hint_location = format!("{}/metadata/version-hint.text", target_url,);
+    file_io
+        .new_output(&version_hint_location)?
+        .write("1".to_string().into())
+        .await?;
+    info!("Wrote version hint: {:?}", version_hint_location);
+
     Ok(())
 }

--- a/src/iceberg_destination.rs
+++ b/src/iceberg_destination.rs
@@ -110,7 +110,12 @@ pub async fn record_batches_to_iceberg(
     )?);
 
     let version_hint_location = format!("{}/metadata/version-hint.text", target_url);
-    if let Ok(_) = file_io.new_input(&version_hint_location)?.read().await {
+    if file_io
+        .new_input(&version_hint_location)?
+        .read()
+        .await
+        .is_ok()
+    {
         return Err(DataLoadingError::IcebergError(iceberg::Error::new(
             iceberg::ErrorKind::FeatureUnsupported,
             "Iceberg table already exists. Writing to an existing table is not implemented",

--- a/src/iceberg_destination.rs
+++ b/src/iceberg_destination.rs
@@ -112,9 +112,8 @@ pub async fn record_batches_to_iceberg(
     let version_hint_location = format!("{}/metadata/version-hint.text", target_url);
     if file_io
         .new_input(&version_hint_location)?
-        .read()
+        .exists()
         .await
-        .is_ok()
     {
         return Err(DataLoadingError::IcebergError(iceberg::Error::new(
             iceberg::ErrorKind::FeatureUnsupported,

--- a/tests/basic_integration.rs
+++ b/tests/basic_integration.rs
@@ -88,12 +88,13 @@ async fn test_pg_to_iceberg() {
     paths.sort();
 
     // THEN iceberg data and metadata files are written
-    assert_eq!(paths.len(), 5);
+    assert_eq!(paths.len(), 6);
     assert!(Regex::new(r"^iceberg/data/part-00000-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.parquet$").unwrap().is_match(paths[0].as_ref()));
     assert!(Regex::new(r"^iceberg/metadata/manifest-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.avro$").unwrap().is_match(paths[1].as_ref()));
     assert!(Regex::new(r"^iceberg/metadata/manifest-list-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}.avro$").unwrap().is_match(paths[2].as_ref()));
     assert_eq!(&paths[3].to_string(), "iceberg/metadata/v0.metadata.json");
     assert_eq!(&paths[4].to_string(), "iceberg/metadata/v1.metadata.json");
+    assert_eq!(&paths[5].to_string(), "iceberg/metadata/version-hint.text");
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Write `version-hint.text` to mimic Iceberg Java implementation behavior with HDFS catalog: https://github.com/apache/iceberg/blob/bfeaaeb8181bf035367761a0c6c907055f4f00cf/core/src/main/java/org/apache/iceberg/hadoop/Util.java#L46

- Error out if there is an existing version hint file, since we don't yet support overwrite/append.