### PR TITLE
Allow overwriting an existing table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.3.0"
-source = "git+https://github.com/splitgraph/iceberg-rust?rev=59e113b4650cfcd52331d3c179154a2cd7f88b6f#59e113b4650cfcd52331d3c179154a2cd7f88b6f"
+source = "git+https://github.com/splitgraph/iceberg-rust?rev=9eaff9bd76a93243eea0360f1833b133f16104d6#9eaff9bd76a93243eea0360f1833b133f16104d6"
 dependencies = [
  "anyhow",
  "apache-avro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.3.0"
-source = "git+https://github.com/splitgraph/iceberg-rust?rev=9eaff9bd76a93243eea0360f1833b133f16104d6#9eaff9bd76a93243eea0360f1833b133f16104d6"
+source = "git+https://github.com/splitgraph/iceberg-rust?rev=e7008f39975ee2f09bc81a74d4ec5c9a3089580d#e7008f39975ee2f09bc81a74d4ec5c9a3089580d"
 dependencies = [
  "anyhow",
  "apache-avro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ deltalake = { version = "0.22" }
 env_logger = "0.11.1"
 fastrand = "2.2.0"
 futures = "0.3"
-iceberg = { git = "https://github.com/splitgraph/iceberg-rust", rev = "59e113b4650cfcd52331d3c179154a2cd7f88b6f" }
+iceberg = { git = "https://github.com/splitgraph/iceberg-rust", rev = "9eaff9bd76a93243eea0360f1833b133f16104d6" }
 log = "0.4"
 native-tls = "0.2.11"
 object_store = { version = "0.11", features = ["aws"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ deltalake = { version = "0.22" }
 env_logger = "0.11.1"
 fastrand = "2.2.0"
 futures = "0.3"
-iceberg = { git = "https://github.com/splitgraph/iceberg-rust", rev = "9eaff9bd76a93243eea0360f1833b133f16104d6" }
+iceberg = { git = "https://github.com/splitgraph/iceberg-rust", rev = "e7008f39975ee2f09bc81a74d4ec5c9a3089580d" }
 log = "0.4"
 native-tls = "0.2.11"
 object_store = { version = "0.11", features = ["aws"] }


### PR DESCRIPTION
Allow the user to pass the `--overwrite` flag to the `parquet-to-iceberg` and `pg-to-iceberg` subcommands.

If the overwrite flag is specified, lakehouse-loader will read the latest existing metadata file and use it as a base for applying changes.

In order to apply changes safely, we need to do a Conditional Put on the object store. This was implemented with a patch to FileIO in our iceberg-rust fork: https://github.com/splitgraph/iceberg-rust/pull/1 . That should be reviewed together with this PR.