### PR TITLE
Append support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,4 +20,6 @@ pub enum DataLoadingError {
     JoinError(#[from] tokio::task::JoinError),
     #[error("optimistic concurrency error")]
     OptimisticConcurrencyError(),
+    #[error("bad input error")]
+    BadInputError(String),
 }


### PR DESCRIPTION
This allows lakehouse-loader to append to existing Iceberg tables using "fast append" (add new manifests instead of rewriting existing manifests).