### PR TITLE
fix: patch arrow to fix decimal parsing with zero scale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,8 +187,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91839b07e474b3995035fd8ac33ee54f9c9ccbbb1ea33d9909c71bffdf1259d"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -196,20 +195,19 @@ dependencies = [
  "arrow-cast",
  "arrow-csv",
  "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
+ "arrow-ipc 53.3.0 (git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict)",
+ "arrow-json 53.3.0 (git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict)",
+ "arrow-ord 53.3.0 (git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict)",
+ "arrow-row 53.3.0 (git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict)",
  "arrow-schema",
  "arrow-select",
- "arrow-string",
+ "arrow-string 53.3.0 (git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict)",
 ]
 
 [[package]]
 name = "arrow-arith"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855c57c4efd26722b044dcd3e348252560e3e0333087fb9f6479dc0bf744054f"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -223,8 +221,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd03279cea46569acf9295f6224fbc370c5df184b4d2ecfe97ccb131d5615a7f"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -240,8 +237,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4a9b9b1d6d7117f6138e13bc4dd5daa7f94e671b70e8c9c4dc37b4f5ecfc16"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "bytes",
  "half",
@@ -251,8 +247,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc70e39916e60c5b7af7a8e2719e3ae589326039e1e863675a008bee5ffe90fd"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -260,7 +255,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "half",
  "lexical-core",
@@ -271,8 +266,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789b2af43c1049b03a8d088ff6b2257cdcea1756cd76b174b1f2600356771b97"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -290,8 +284,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e75edf21ffd53744a9b8e3ed11101f610e7ceb1a29860432824f1834a1f623"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -314,10 +307,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-ipc"
+version = "53.3.0"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
 name = "arrow-json"
 version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66ff2fedc1222942d0bd2fd391cb14a85baa3857be95c9373179bd616753b85"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.6.0",
+ "lexical-core",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-json"
+version = "53.3.0"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -349,6 +374,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-ord"
+version = "53.3.0"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-row"
 version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,10 +402,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-row"
+version = "53.3.0"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
+dependencies = [
+ "ahash 0.8.11",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
 name = "arrow-schema"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95513080e728e4cec37f1ff5af4f12c9688d47795d17cda80b6ec2cf74d4678"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "serde",
 ]
@@ -374,8 +425,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "53.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e415279094ea70323c032c6e739c48ad8d80e78a09bef7117b8718ad5bf3722"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -390,6 +440,22 @@ name = "arrow-string"
 version = "53.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d956cae7002eb8d83a27dbd34daaea1cf5b75852f0b84deb4d93a276e92bbf"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "53.3.0"
+source = "git+https://github.com/splitgraph/arrow-rs?branch=backport-fix-zero-scale-decimal-parse-strict#ae7d2f1c801dfa3ded6329f3f060e7993e628df0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -470,12 +536,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -741,25 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
-dependencies = [
- "async-trait",
- "json5",
- "lazy_static",
- "nom",
- "pathdiff",
- "ron",
- "rust-ini 0.18.0",
- "serde",
- "serde_json",
- "toml",
- "yaml-rust",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,8 +1014,8 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-json",
- "arrow-ord",
+ "arrow-json 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-ord 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-schema",
  "arrow-select",
  "bytes",
@@ -1028,10 +1069,10 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
+ "arrow-ipc 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-json 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-ord 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrow-row 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-schema",
  "arrow-select",
  "async-trait",
@@ -1137,12 +1178,6 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
-
-[[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dlv-list"
@@ -1675,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.3.0"
-source = "git+https://github.com/splitgraph/iceberg-rust?rev=e7008f39975ee2f09bc81a74d4ec5c9a3089580d#e7008f39975ee2f09bc81a74d4ec5c9a3089580d"
+source = "git+https://github.com/apache/iceberg-rust?rev=e7008f39975ee2f09bc81a74d4ec5c9a3089580d#e7008f39975ee2f09bc81a74d4ec5c9a3089580d"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -1683,10 +1718,10 @@ dependencies = [
  "arrow-arith",
  "arrow-array",
  "arrow-cast",
- "arrow-ord",
+ "arrow-ord 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-schema",
  "arrow-select",
- "arrow-string",
+ "arrow-string 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bimap",
  "bitvec",
@@ -1937,27 +1972,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "lakehouse-loader"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "arrow-buffer",
  "arrow-schema",
  "async-trait",
  "bytes",
  "clap",
- "config",
  "deltalake",
  "env_logger",
  "fastrand",
@@ -2088,12 +2110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,12 +2173,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2230,16 +2240,6 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2349,7 +2349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -2387,7 +2387,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backon",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "crc32c",
@@ -2472,21 +2472,11 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list 0.3.0",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
- "dlv-list 0.5.2",
+ "dlv-list",
  "hashbrown 0.14.5",
 ]
 
@@ -2530,10 +2520,10 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
- "arrow-ipc",
+ "arrow-ipc 53.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrow-schema",
  "arrow-select",
- "base64 0.22.1",
+ "base64",
  "brotli",
  "bytes",
  "chrono",
@@ -2571,61 +2561,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pest"
-version = "2.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
-dependencies = [
- "memchr",
- "thiserror 1.0.69",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.89",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "phf"
@@ -2712,7 +2651,7 @@ name = "postgres-protocol"
 version = "0.6.6"
 source = "git+https://github.com/splitgraph/rust-postgres?rev=88c2c7714a4558aed6a63e2e2b140a8359568858#88c2c7714a4558aed6a63e2e2b140a8359568858"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2995,7 +2934,7 @@ checksum = "eb0075a66c8bfbf4cc8b70dca166e722e1f55a3ea9250ecbb85f4d92a5f64149"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "form_urlencoded",
  "getrandom",
@@ -3008,7 +2947,7 @@ dependencies = [
  "quick-xml 0.35.0",
  "rand",
  "reqwest",
- "rust-ini 0.21.1",
+ "rust-ini",
  "serde",
  "serde_json",
  "sha1",
@@ -3021,7 +2960,7 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3122,34 +3061,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "serde",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap 0.4.3",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
 dependencies = [
  "cfg-if",
- "ordered-multimap 0.7.3",
+ "ordered-multimap",
  "trim-in-place",
 ]
 
@@ -3418,7 +3336,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3887,15 +3805,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4023,12 +3932,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"
@@ -4462,15 +4365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,15 @@ edition = "2021"
 [dependencies]
 
 arrow = { version = "53" }
-arrow-buffer = { version = "53" }
 arrow-schema = { version = "53" }
 async-trait = "0.1"
 bytes = "1.4.0"
 clap = { version = "4.5", features = [ "derive" ] }
-config = "0.13.3"
 deltalake = { version = "0.22" }
 env_logger = "0.11.1"
 fastrand = "2.2.0"
 futures = "0.3"
-iceberg = { git = "https://github.com/splitgraph/iceberg-rust", rev = "e7008f39975ee2f09bc81a74d4ec5c9a3089580d" }
+iceberg = { git = "https://github.com/apache/iceberg-rust", rev = "e7008f39975ee2f09bc81a74d4ec5c9a3089580d" }
 itertools = "0.13.0"
 log = "0.4"
 native-tls = "0.2.11"
@@ -32,6 +30,17 @@ tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "signa
 tokio-postgres = { version = "0.7.10", git = "https://github.com/splitgraph/rust-postgres", rev = "88c2c7714a4558aed6a63e2e2b140a8359568858" }
 url = "2.5.0"
 uuid = "1.2.1"
+
+[patch.crates-io]
+arrow = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-arith = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-array = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-buffer = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-cast = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-csv = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-data = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-schema = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
+arrow-select = { git = "https://github.com/splitgraph/arrow-rs", branch = "backport-fix-zero-scale-decimal-parse-strict" }
 
 [dev-dependencies]
 regex = "1.11"


### PR DESCRIPTION
Pick-up backport of https://github.com/apache/arrow-rs/pull/8702.